### PR TITLE
fix: [#391] TMJ tilesets with colliders crash excalibur

### DIFF
--- a/src/tiled-map-resource.ts
+++ b/src/tiled-map-resource.ts
@@ -27,7 +27,7 @@ import {
    Animation,
    ParallaxComponent
 } from 'excalibur';
-import { ExcaliburData } from './tiled-types';
+import { ExcaliburData, TiledPoint } from './tiled-types';
 import { RawTiledTileset } from "./raw-tiled-tileset";
 import { RawTiledLayer } from "./raw-tiled-layer";
 import { RawTiledMap } from "./raw-tiled-map";
@@ -508,16 +508,13 @@ export class TiledMapResource implements Loadable<TiledMap> {
       if (tileWithObjects && tileWithObjects.objectgroup) {
          const result = [];
          for (const polygon of tileWithObjects.objectgroup.getPolygons()) {
-            const offset = vec(polygon.x, polygon.y);
-            const points = polygon.polygon.points;
-            const parsed = points.split(" ")
-               .map((tp: string) => {
-                  const point = tp.split(",");
-                  return vec(Number.parseFloat(point[0]), Number.parseFloat(point[1])).add(offset)
-               });
-            const poly = Shape.Polygon(parsed);
-            poly.points = this._transformPoints(poly.points, tileset, gid);
-            result.push(poly);
+            if (polygon.polygon) {
+               const offset = vec(polygon.x, polygon.y);
+               let parsed: Vector[] = polygon.polygon.map(p => vec(p.x, p.y).add(offset));
+               const poly = Shape.Polygon(parsed);
+               poly.points = this._transformPoints(poly.points, tileset, gid);
+               result.push(poly);
+            }
          }
 
          for (const box of tileWithObjects.objectgroup.getBoxes()) {

--- a/src/tiled-object.ts
+++ b/src/tiled-object.ts
@@ -7,9 +7,6 @@ import { toRadians } from "excalibur";
 export interface Polygon {
    x: number;
    y: number;
-   polygon: {
-      points: string;
-   }
 }
 
 export interface Box {

--- a/src/tiled-tileset.ts
+++ b/src/tiled-tileset.ts
@@ -3,7 +3,7 @@ import { Matrix, vec, Animation, Sprite, Frame, AnimationStrategy } from 'excali
 import * as parser from 'fast-xml-parser'
 import { TiledObjectGroup } from '.';
 
-import { TiledFrame, TiledGrid, TiledMapTerrain, TiledProperty, TiledTileOffset, TiledWangSet } from "./tiled-types";
+import { TiledFrame, TiledGrid, TiledMapTerrain, TiledPoint, TiledProperty, TiledTileOffset, TiledWangSet } from "./tiled-types";
 import { RawTiledTileset } from "./raw-tiled-tileset";
 import { RawTilesetTile } from "./raw-tileset-tile";
 import { TiledMapResource } from './tiled-map-resource';
@@ -189,6 +189,29 @@ export class TiledTilesetTile {
       if (rawTilesetTile.terrain) {
          tile.terrain = rawTilesetTile.terrain;
       }
+
+      // Parse xml object groups if necessary
+      // <tile id="36">
+      //    <objectgroup draworder="index" id="2">
+      //       <object id="1" x="1.52937" y="95.4681">
+      //       <polygon points="0,0 54.7017,-32.2916 110.109,0.176457 55.0546,32.6446"/>
+      //       </object>
+      //    </objectgroup>
+      // </tile>
+      if (tile.objectgroup) {
+         for (const polygon of tile.objectgroup.getPolygons()) {
+            if ((polygon.polygon as any).points) {
+               const points = (polygon.polygon as any).points as string;
+               const parsed = points.split(" ")
+               .map((tp: string) => {
+                  const point = tp.split(",");
+                  return {x: Number.parseFloat(point[0]), y: Number.parseFloat(point[1]) } as TiledPoint
+               });
+               polygon.polygon = parsed;
+            }
+         }
+      }
+
       if (rawTilesetTile.animation) {
          tile.animation = Array.isArray(rawTilesetTile.animation) ? rawTilesetTile.animation : [...(rawTilesetTile.animation as any).frame];
          if (tile.properties) {


### PR DESCRIPTION
closes #391 

This PR fixes an issue where tileset parsing of TMJ tilesets would error and crash excalibur.

 