### PR TITLE
fix: [#483] Add optional JSDOM dependency for Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
          "devDependencies": {
             "@playwright/test": "1.40.1",
             "@types/jasmine": "5.1.4",
+            "@types/jsdom": "21.1.6",
             "@types/json-diff": "1.0.3",
             "@types/node": "20.10.6",
             "@types/pako": "1.0.7",
@@ -41,8 +42,22 @@
             "webpack-dev-middleware": "7.0.0",
             "webpack-dev-server": "4.15.1"
          },
+         "optionalDependencies": {
+            "jsdom": "^23.2.0"
+         },
          "peerDependencies": {
             "excalibur": "~0.28.5"
+         }
+      },
+      "node_modules/@asamuzakjp/dom-selector": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+         "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+         "optional": true,
+         "dependencies": {
+            "bidi-js": "^1.0.3",
+            "css-tree": "^2.3.1",
+            "is-potential-custom-element-name": "^1.0.1"
          }
       },
       "node_modules/@colors/colors": {
@@ -287,6 +302,17 @@
          "integrity": "sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==",
          "dev": true
       },
+      "node_modules/@types/jsdom": {
+         "version": "21.1.6",
+         "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+         "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+         "dev": true,
+         "dependencies": {
+            "@types/node": "*",
+            "@types/tough-cookie": "*",
+            "parse5": "^7.0.0"
+         }
+      },
       "node_modules/@types/json-diff": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/@types/json-diff/-/json-diff-1.0.3.tgz",
@@ -385,6 +411,12 @@
          "dependencies": {
             "@types/node": "*"
          }
+      },
+      "node_modules/@types/tough-cookie": {
+         "version": "4.0.5",
+         "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+         "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+         "dev": true
       },
       "node_modules/@types/webpack-env": {
          "version": "1.18.4",
@@ -658,6 +690,41 @@
             "node": ">=0.4.0"
          }
       },
+      "node_modules/agent-base": {
+         "version": "7.1.0",
+         "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+         "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+         "optional": true,
+         "dependencies": {
+            "debug": "^4.3.4"
+         },
+         "engines": {
+            "node": ">= 14"
+         }
+      },
+      "node_modules/agent-base/node_modules/debug": {
+         "version": "4.3.4",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+         "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+         "optional": true,
+         "dependencies": {
+            "ms": "2.1.2"
+         },
+         "engines": {
+            "node": ">=6.0"
+         },
+         "peerDependenciesMeta": {
+            "supports-color": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/agent-base/node_modules/ms": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+         "optional": true
+      },
       "node_modules/ajv": {
          "version": "6.12.6",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -823,6 +890,12 @@
             "lodash": "^4.17.14"
          }
       },
+      "node_modules/asynckit": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+         "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+         "optional": true
+      },
       "node_modules/available-typed-arrays": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -893,6 +966,15 @@
          "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
          "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
          "dev": true
+      },
+      "node_modules/bidi-js": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+         "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+         "optional": true,
+         "dependencies": {
+            "require-from-string": "^2.0.2"
+         }
       },
       "node_modules/big.js": {
          "version": "5.2.2",
@@ -1307,6 +1389,18 @@
             "node": ">=0.1.90"
          }
       },
+      "node_modules/combined-stream": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+         "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+         "optional": true,
+         "dependencies": {
+            "delayed-stream": "~1.0.0"
+         },
+         "engines": {
+            "node": ">= 0.8"
+         }
+      },
       "node_modules/compare-versions": {
          "version": "6.1.0",
          "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
@@ -1571,11 +1665,49 @@
             "node": "*"
          }
       },
+      "node_modules/css-tree": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+         "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+         "optional": true,
+         "dependencies": {
+            "mdn-data": "2.0.30",
+            "source-map-js": "^1.0.1"
+         },
+         "engines": {
+            "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+         }
+      },
+      "node_modules/cssstyle": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+         "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+         "optional": true,
+         "dependencies": {
+            "rrweb-cssom": "^0.6.0"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
       "node_modules/custom-event": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
          "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
          "dev": true
+      },
+      "node_modules/data-urls": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+         "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+         "optional": true,
+         "dependencies": {
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0"
+         },
+         "engines": {
+            "node": ">=18"
+         }
       },
       "node_modules/date-format": {
          "version": "4.0.14",
@@ -1600,6 +1732,12 @@
          "dependencies": {
             "ms": "2.0.0"
          }
+      },
+      "node_modules/decimal.js": {
+         "version": "10.4.3",
+         "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+         "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+         "optional": true
       },
       "node_modules/default-gateway": {
          "version": "6.0.3",
@@ -1651,6 +1789,15 @@
          },
          "funding": {
             "url": "https://github.com/sponsors/ljharb"
+         }
+      },
+      "node_modules/delayed-stream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+         "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+         "optional": true,
+         "engines": {
+            "node": ">=0.4.0"
          }
       },
       "node_modules/depd": {
@@ -1920,6 +2067,18 @@
          "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
          "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
          "dev": true
+      },
+      "node_modules/entities": {
+         "version": "4.5.0",
+         "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+         "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+         "devOptional": true,
+         "engines": {
+            "node": ">=0.12"
+         },
+         "funding": {
+            "url": "https://github.com/fb55/entities?sponsor=1"
+         }
       },
       "node_modules/envinfo": {
          "version": "7.11.0",
@@ -2379,6 +2538,20 @@
             "is-callable": "^1.1.3"
          }
       },
+      "node_modules/form-data": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+         "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+         "optional": true,
+         "dependencies": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+         },
+         "engines": {
+            "node": ">= 6"
+         }
+      },
       "node_modules/forwarded": {
          "version": "0.2.0",
          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2790,6 +2963,42 @@
             "node": ">=8.0.0"
          }
       },
+      "node_modules/http-proxy-agent": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+         "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+         "optional": true,
+         "dependencies": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+         },
+         "engines": {
+            "node": ">= 14"
+         }
+      },
+      "node_modules/http-proxy-agent/node_modules/debug": {
+         "version": "4.3.4",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+         "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+         "optional": true,
+         "dependencies": {
+            "ms": "2.1.2"
+         },
+         "engines": {
+            "node": ">=6.0"
+         },
+         "peerDependenciesMeta": {
+            "supports-color": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/http-proxy-agent/node_modules/ms": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+         "optional": true
+      },
       "node_modules/http-proxy-middleware": {
          "version": "2.0.6",
          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -2858,6 +3067,42 @@
          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
          "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
          "dev": true
+      },
+      "node_modules/https-proxy-agent": {
+         "version": "7.0.2",
+         "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+         "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+         "optional": true,
+         "dependencies": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+         },
+         "engines": {
+            "node": ">= 14"
+         }
+      },
+      "node_modules/https-proxy-agent/node_modules/debug": {
+         "version": "4.3.4",
+         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+         "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+         "optional": true,
+         "dependencies": {
+            "ms": "2.1.2"
+         },
+         "engines": {
+            "node": ">=6.0"
+         },
+         "peerDependenciesMeta": {
+            "supports-color": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/https-proxy-agent/node_modules/ms": {
+         "version": "2.1.2",
+         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+         "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+         "optional": true
       },
       "node_modules/human-signals": {
          "version": "2.1.0",
@@ -3120,6 +3365,12 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/is-potential-custom-element-name": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+         "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+         "optional": true
+      },
       "node_modules/is-stream": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -3225,6 +3476,103 @@
          },
          "funding": {
             "url": "https://github.com/chalk/supports-color?sponsor=1"
+         }
+      },
+      "node_modules/jsdom": {
+         "version": "23.2.0",
+         "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+         "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+         "optional": true,
+         "dependencies": {
+            "@asamuzakjp/dom-selector": "^2.0.1",
+            "cssstyle": "^4.0.1",
+            "data-urls": "^5.0.0",
+            "decimal.js": "^10.4.3",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^4.0.0",
+            "http-proxy-agent": "^7.0.0",
+            "https-proxy-agent": "^7.0.2",
+            "is-potential-custom-element-name": "^1.0.1",
+            "parse5": "^7.1.2",
+            "rrweb-cssom": "^0.6.0",
+            "saxes": "^6.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.1.3",
+            "w3c-xmlserializer": "^5.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^3.1.1",
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0",
+            "ws": "^8.16.0",
+            "xml-name-validator": "^5.0.0"
+         },
+         "engines": {
+            "node": ">=18"
+         },
+         "peerDependencies": {
+            "canvas": "^2.11.2"
+         },
+         "peerDependenciesMeta": {
+            "canvas": {
+               "optional": true
+            }
+         }
+      },
+      "node_modules/jsdom/node_modules/html-encoding-sniffer": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+         "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+         "optional": true,
+         "dependencies": {
+            "whatwg-encoding": "^3.1.1"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
+      "node_modules/jsdom/node_modules/iconv-lite": {
+         "version": "0.6.3",
+         "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+         "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+         "optional": true,
+         "dependencies": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+         },
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
+      "node_modules/jsdom/node_modules/whatwg-encoding": {
+         "version": "3.1.1",
+         "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+         "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+         "optional": true,
+         "dependencies": {
+            "iconv-lite": "0.6.3"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
+      "node_modules/jsdom/node_modules/ws": {
+         "version": "8.16.0",
+         "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+         "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+         "optional": true,
+         "engines": {
+            "node": ">=10.0.0"
+         },
+         "peerDependencies": {
+            "bufferutil": "^4.0.1",
+            "utf-8-validate": ">=5.0.2"
+         },
+         "peerDependenciesMeta": {
+            "bufferutil": {
+               "optional": true
+            },
+            "utf-8-validate": {
+               "optional": true
+            }
          }
       },
       "node_modules/json-diff": {
@@ -3541,6 +3889,12 @@
             "safe-buffer": "^5.1.2"
          }
       },
+      "node_modules/mdn-data": {
+         "version": "2.0.30",
+         "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+         "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+         "optional": true
+      },
       "node_modules/media-typer": {
          "version": "0.3.0",
          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -3639,7 +3993,7 @@
          "version": "1.52.0",
          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-         "dev": true,
+         "devOptional": true,
          "engines": {
             "node": ">= 0.6"
          }
@@ -3648,7 +4002,7 @@
          "version": "2.1.35",
          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-         "dev": true,
+         "devOptional": true,
          "dependencies": {
             "mime-db": "1.52.0"
          },
@@ -4054,6 +4408,18 @@
             "safe-buffer": "^5.1.1"
          }
       },
+      "node_modules/parse5": {
+         "version": "7.1.2",
+         "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+         "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+         "devOptional": true,
+         "dependencies": {
+            "entities": "^4.4.0"
+         },
+         "funding": {
+            "url": "https://github.com/inikulin/parse5?sponsor=1"
+         }
+      },
       "node_modules/parseurl": {
          "version": "1.3.3",
          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -4264,6 +4630,12 @@
             "node": ">= 0.10"
          }
       },
+      "node_modules/psl": {
+         "version": "1.9.0",
+         "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+         "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+         "optional": true
+      },
       "node_modules/public-encrypt": {
          "version": "4.0.3",
          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -4288,7 +4660,7 @@
          "version": "2.3.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-         "dev": true,
+         "devOptional": true,
          "engines": {
             "node": ">=6"
          }
@@ -4325,6 +4697,12 @@
          "engines": {
             "node": ">=0.4.x"
          }
+      },
+      "node_modules/querystringify": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+         "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+         "optional": true
       },
       "node_modules/quill-delta": {
          "version": "5.1.0",
@@ -4455,7 +4833,7 @@
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-         "dev": true,
+         "devOptional": true,
          "engines": {
             "node": ">=0.10.0"
          }
@@ -4464,7 +4842,7 @@
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
          "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-         "dev": true
+         "devOptional": true
       },
       "node_modules/resolve": {
          "version": "1.22.8",
@@ -4544,6 +4922,12 @@
             "inherits": "^2.0.1"
          }
       },
+      "node_modules/rrweb-cssom": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+         "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+         "optional": true
+      },
       "node_modules/rxjs": {
          "version": "7.8.1",
          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -4578,7 +4962,19 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-         "dev": true
+         "devOptional": true
+      },
+      "node_modules/saxes": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+         "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+         "optional": true,
+         "dependencies": {
+            "xmlchars": "^2.2.0"
+         },
+         "engines": {
+            "node": ">=v12.22.7"
+         }
       },
       "node_modules/schema-utils": {
          "version": "3.3.0",
@@ -5010,6 +5406,15 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/source-map-js": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+         "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+         "optional": true,
+         "engines": {
+            "node": ">=0.10.0"
+         }
+      },
       "node_modules/source-map-support": {
          "version": "0.5.21",
          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -5237,6 +5642,12 @@
             "url": "https://github.com/sponsors/ljharb"
          }
       },
+      "node_modules/symbol-tree": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+         "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+         "optional": true
+      },
       "node_modules/tapable": {
          "version": "2.2.1",
          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -5374,6 +5785,42 @@
          "dev": true,
          "engines": {
             "node": ">=6"
+         }
+      },
+      "node_modules/tough-cookie": {
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+         "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+         "optional": true,
+         "dependencies": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.2.0",
+            "url-parse": "^1.5.3"
+         },
+         "engines": {
+            "node": ">=6"
+         }
+      },
+      "node_modules/tough-cookie/node_modules/universalify": {
+         "version": "0.2.0",
+         "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+         "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+         "optional": true,
+         "engines": {
+            "node": ">= 4.0.0"
+         }
+      },
+      "node_modules/tr46": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+         "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+         "optional": true,
+         "dependencies": {
+            "punycode": "^2.3.1"
+         },
+         "engines": {
+            "node": ">=18"
          }
       },
       "node_modules/ts-loader": {
@@ -5570,6 +6017,16 @@
          "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
          "dev": true
       },
+      "node_modules/url-parse": {
+         "version": "1.5.10",
+         "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+         "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+         "optional": true,
+         "dependencies": {
+            "querystringify": "^2.1.1",
+            "requires-port": "^1.0.0"
+         }
+      },
       "node_modules/url/node_modules/punycode": {
          "version": "1.4.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -5652,6 +6109,18 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/w3c-xmlserializer": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+         "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+         "optional": true,
+         "dependencies": {
+            "xml-name-validator": "^5.0.0"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
       "node_modules/watchpack": {
          "version": "2.4.0",
          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -5672,6 +6141,15 @@
          "dev": true,
          "dependencies": {
             "minimalistic-assert": "^1.0.0"
+         }
+      },
+      "node_modules/webidl-conversions": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+         "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+         "optional": true,
+         "engines": {
+            "node": ">=12"
          }
       },
       "node_modules/webpack": {
@@ -6104,6 +6582,28 @@
             "node": ">=0.10.0"
          }
       },
+      "node_modules/whatwg-mimetype": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+         "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+         "optional": true,
+         "engines": {
+            "node": ">=18"
+         }
+      },
+      "node_modules/whatwg-url": {
+         "version": "14.0.0",
+         "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+         "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+         "optional": true,
+         "dependencies": {
+            "tr46": "^5.0.0",
+            "webidl-conversions": "^7.0.0"
+         },
+         "engines": {
+            "node": ">=18"
+         }
+      },
       "node_modules/which": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6194,6 +6694,21 @@
             }
          }
       },
+      "node_modules/xml-name-validator": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+         "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+         "optional": true,
+         "engines": {
+            "node": ">=18"
+         }
+      },
+      "node_modules/xmlchars": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+         "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+         "optional": true
+      },
       "node_modules/xtend": {
          "version": "4.0.2",
          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -6260,6 +6775,17 @@
       }
    },
    "dependencies": {
+      "@asamuzakjp/dom-selector": {
+         "version": "2.0.2",
+         "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-2.0.2.tgz",
+         "integrity": "sha512-x1KXOatwofR6ZAYzXRBL5wrdV0vwNxlTCK9NCuLqAzQYARqGcvFwiJA6A1ERuh+dgeA4Dxm3JBYictIes+SqUQ==",
+         "optional": true,
+         "requires": {
+            "bidi-js": "^1.0.3",
+            "css-tree": "^2.3.1",
+            "is-potential-custom-element-name": "^1.0.1"
+         }
+      },
       "@colors/colors": {
          "version": "1.5.0",
          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
@@ -6481,6 +7007,17 @@
          "integrity": "sha512-px7OMFO/ncXxixDe1zR13V1iycqWae0MxTaw62RpFlksUi5QuNWgQJFkTQjIOvrmutJbI7Fp2Y2N1F6D2R4G6w==",
          "dev": true
       },
+      "@types/jsdom": {
+         "version": "21.1.6",
+         "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.6.tgz",
+         "integrity": "sha512-/7kkMsC+/kMs7gAYmmBR9P0vGTnOoLhQhyhQJSlXGI5bzTHp6xdo0TtKWQAsz6pmSAeVqKSbqeyP6hytqr9FDw==",
+         "dev": true,
+         "requires": {
+            "@types/node": "*",
+            "@types/tough-cookie": "*",
+            "parse5": "^7.0.0"
+         }
+      },
       "@types/json-diff": {
          "version": "1.0.3",
          "resolved": "https://registry.npmjs.org/@types/json-diff/-/json-diff-1.0.3.tgz",
@@ -6579,6 +7116,12 @@
          "requires": {
             "@types/node": "*"
          }
+      },
+      "@types/tough-cookie": {
+         "version": "4.0.5",
+         "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+         "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+         "dev": true
       },
       "@types/webpack-env": {
          "version": "1.18.4",
@@ -6812,6 +7355,32 @@
          "integrity": "sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==",
          "dev": true
       },
+      "agent-base": {
+         "version": "7.1.0",
+         "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+         "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+         "optional": true,
+         "requires": {
+            "debug": "^4.3.4"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.3.4",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+               "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+               "optional": true,
+               "requires": {
+                  "ms": "2.1.2"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "optional": true
+            }
+         }
+      },
       "ajv": {
          "version": "6.12.6",
          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6945,6 +7514,12 @@
             "lodash": "^4.17.14"
          }
       },
+      "asynckit": {
+         "version": "0.4.0",
+         "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+         "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+         "optional": true
+      },
       "available-typed-arrays": {
          "version": "1.0.5",
          "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -6991,6 +7566,15 @@
          "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
          "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
          "dev": true
+      },
+      "bidi-js": {
+         "version": "1.0.3",
+         "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+         "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+         "optional": true,
+         "requires": {
+            "require-from-string": "^2.0.2"
+         }
       },
       "big.js": {
          "version": "5.2.2",
@@ -7305,6 +7889,15 @@
          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
          "dev": true
       },
+      "combined-stream": {
+         "version": "1.0.8",
+         "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+         "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+         "optional": true,
+         "requires": {
+            "delayed-stream": "~1.0.0"
+         }
+      },
       "compare-versions": {
          "version": "6.1.0",
          "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
@@ -7523,11 +8116,40 @@
             "randomfill": "^1.0.3"
          }
       },
+      "css-tree": {
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+         "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+         "optional": true,
+         "requires": {
+            "mdn-data": "2.0.30",
+            "source-map-js": "^1.0.1"
+         }
+      },
+      "cssstyle": {
+         "version": "4.0.1",
+         "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+         "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+         "optional": true,
+         "requires": {
+            "rrweb-cssom": "^0.6.0"
+         }
+      },
       "custom-event": {
          "version": "1.0.1",
          "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
          "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
          "dev": true
+      },
+      "data-urls": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+         "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+         "optional": true,
+         "requires": {
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0"
+         }
       },
       "date-format": {
          "version": "4.0.14",
@@ -7549,6 +8171,12 @@
          "requires": {
             "ms": "2.0.0"
          }
+      },
+      "decimal.js": {
+         "version": "10.4.3",
+         "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+         "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+         "optional": true
       },
       "default-gateway": {
          "version": "6.0.3",
@@ -7586,6 +8214,12 @@
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
          }
+      },
+      "delayed-stream": {
+         "version": "1.0.0",
+         "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+         "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+         "optional": true
       },
       "depd": {
          "version": "2.0.0",
@@ -7804,6 +8438,12 @@
          "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
          "integrity": "sha512-GHrMyVZQWvTIdDtpiEXdHZnFQKzeO09apj8Cbl4pKWy4i0Oprcq17usfDt5aO63swf0JOeMWjWQE/LzgSRuWpA==",
          "dev": true
+      },
+      "entities": {
+         "version": "4.5.0",
+         "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+         "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+         "devOptional": true
       },
       "envinfo": {
          "version": "7.11.0",
@@ -8162,6 +8802,17 @@
             "is-callable": "^1.1.3"
          }
       },
+      "form-data": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+         "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+         "optional": true,
+         "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+         }
+      },
       "forwarded": {
          "version": "0.2.0",
          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -8479,6 +9130,33 @@
             "requires-port": "^1.0.0"
          }
       },
+      "http-proxy-agent": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz",
+         "integrity": "sha512-+ZT+iBxVUQ1asugqnD6oWoRiS25AkjNfG085dKJGtGxkdwLQrMKU5wJr2bOOFAXzKcTuqq+7fZlTMgG3SRfIYQ==",
+         "optional": true,
+         "requires": {
+            "agent-base": "^7.1.0",
+            "debug": "^4.3.4"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.3.4",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+               "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+               "optional": true,
+               "requires": {
+                  "ms": "2.1.2"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "optional": true
+            }
+         }
+      },
       "http-proxy-middleware": {
          "version": "2.0.6",
          "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
@@ -8526,6 +9204,33 @@
          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
          "integrity": "sha512-J+FkSdyD+0mA0N+81tMotaRMfSL9SGi+xpD3T6YApKsc3bGSXJlfXri3VyFOeYkfLRQisDk1W+jIFFKBeUBbBg==",
          "dev": true
+      },
+      "https-proxy-agent": {
+         "version": "7.0.2",
+         "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+         "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+         "optional": true,
+         "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+         },
+         "dependencies": {
+            "debug": {
+               "version": "4.3.4",
+               "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+               "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+               "optional": true,
+               "requires": {
+                  "ms": "2.1.2"
+               }
+            },
+            "ms": {
+               "version": "2.1.2",
+               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+               "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+               "optional": true
+            }
+         }
       },
       "human-signals": {
          "version": "2.1.0",
@@ -8690,6 +9395,12 @@
          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
          "dev": true
       },
+      "is-potential-custom-element-name": {
+         "version": "1.0.1",
+         "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+         "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+         "optional": true
+      },
       "is-stream": {
          "version": "2.0.1",
          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -8763,6 +9474,71 @@
                "requires": {
                   "has-flag": "^4.0.0"
                }
+            }
+         }
+      },
+      "jsdom": {
+         "version": "23.2.0",
+         "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-23.2.0.tgz",
+         "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
+         "optional": true,
+         "requires": {
+            "@asamuzakjp/dom-selector": "^2.0.1",
+            "cssstyle": "^4.0.1",
+            "data-urls": "^5.0.0",
+            "decimal.js": "^10.4.3",
+            "form-data": "^4.0.0",
+            "html-encoding-sniffer": "^4.0.0",
+            "http-proxy-agent": "^7.0.0",
+            "https-proxy-agent": "^7.0.2",
+            "is-potential-custom-element-name": "^1.0.1",
+            "parse5": "^7.1.2",
+            "rrweb-cssom": "^0.6.0",
+            "saxes": "^6.0.0",
+            "symbol-tree": "^3.2.4",
+            "tough-cookie": "^4.1.3",
+            "w3c-xmlserializer": "^5.0.0",
+            "webidl-conversions": "^7.0.0",
+            "whatwg-encoding": "^3.1.1",
+            "whatwg-mimetype": "^4.0.0",
+            "whatwg-url": "^14.0.0",
+            "ws": "^8.16.0",
+            "xml-name-validator": "^5.0.0"
+         },
+         "dependencies": {
+            "html-encoding-sniffer": {
+               "version": "4.0.0",
+               "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+               "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+               "optional": true,
+               "requires": {
+                  "whatwg-encoding": "^3.1.1"
+               }
+            },
+            "iconv-lite": {
+               "version": "0.6.3",
+               "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+               "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+               "optional": true,
+               "requires": {
+                  "safer-buffer": ">= 2.1.2 < 3.0.0"
+               }
+            },
+            "whatwg-encoding": {
+               "version": "3.1.1",
+               "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+               "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+               "optional": true,
+               "requires": {
+                  "iconv-lite": "0.6.3"
+               }
+            },
+            "ws": {
+               "version": "8.16.0",
+               "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+               "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+               "optional": true,
+               "requires": {}
             }
          }
       },
@@ -9006,6 +9782,12 @@
             "safe-buffer": "^5.1.2"
          }
       },
+      "mdn-data": {
+         "version": "2.0.30",
+         "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+         "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+         "optional": true
+      },
       "media-typer": {
          "version": "0.3.0",
          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -9078,13 +9860,13 @@
          "version": "1.52.0",
          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
          "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-         "dev": true
+         "devOptional": true
       },
       "mime-types": {
          "version": "2.1.35",
          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
          "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-         "dev": true,
+         "devOptional": true,
          "requires": {
             "mime-db": "1.52.0"
          }
@@ -9393,6 +10175,15 @@
             "safe-buffer": "^5.1.1"
          }
       },
+      "parse5": {
+         "version": "7.1.2",
+         "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+         "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+         "devOptional": true,
+         "requires": {
+            "entities": "^4.4.0"
+         }
+      },
       "parseurl": {
          "version": "1.3.3",
          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9552,6 +10343,12 @@
             }
          }
       },
+      "psl": {
+         "version": "1.9.0",
+         "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+         "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+         "optional": true
+      },
       "public-encrypt": {
          "version": "4.0.3",
          "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
@@ -9578,7 +10375,7 @@
          "version": "2.3.1",
          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
          "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-         "dev": true
+         "devOptional": true
       },
       "qjobs": {
          "version": "1.2.0",
@@ -9600,6 +10397,12 @@
          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
          "integrity": "sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==",
          "dev": true
+      },
+      "querystringify": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+         "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+         "optional": true
       },
       "quill-delta": {
          "version": "5.1.0",
@@ -9699,13 +10502,13 @@
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
          "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-         "dev": true
+         "devOptional": true
       },
       "requires-port": {
          "version": "1.0.0",
          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
          "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-         "dev": true
+         "devOptional": true
       },
       "resolve": {
          "version": "1.22.8",
@@ -9764,6 +10567,12 @@
             "inherits": "^2.0.1"
          }
       },
+      "rrweb-cssom": {
+         "version": "0.6.0",
+         "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+         "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+         "optional": true
+      },
       "rxjs": {
          "version": "7.8.1",
          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
@@ -9784,7 +10593,16 @@
          "version": "2.1.2",
          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-         "dev": true
+         "devOptional": true
+      },
+      "saxes": {
+         "version": "6.0.0",
+         "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+         "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+         "optional": true,
+         "requires": {
+            "xmlchars": "^2.2.0"
+         }
       },
       "schema-utils": {
          "version": "3.3.0",
@@ -10123,6 +10941,12 @@
          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
          "dev": true
       },
+      "source-map-js": {
+         "version": "1.0.2",
+         "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+         "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+         "optional": true
+      },
       "source-map-support": {
          "version": "0.5.21",
          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -10305,6 +11129,12 @@
          "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
          "dev": true
       },
+      "symbol-tree": {
+         "version": "3.2.4",
+         "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+         "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+         "optional": true
+      },
       "tapable": {
          "version": "2.2.1",
          "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -10395,6 +11225,35 @@
          "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
          "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
          "dev": true
+      },
+      "tough-cookie": {
+         "version": "4.1.3",
+         "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+         "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+         "optional": true,
+         "requires": {
+            "psl": "^1.1.33",
+            "punycode": "^2.1.1",
+            "universalify": "^0.2.0",
+            "url-parse": "^1.5.3"
+         },
+         "dependencies": {
+            "universalify": {
+               "version": "0.2.0",
+               "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+               "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+               "optional": true
+            }
+         }
+      },
+      "tr46": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+         "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+         "optional": true,
+         "requires": {
+            "punycode": "^2.3.1"
+         }
       },
       "ts-loader": {
          "version": "9.5.1",
@@ -10537,6 +11396,16 @@
          "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
          "dev": true
       },
+      "url-parse": {
+         "version": "1.5.10",
+         "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+         "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+         "optional": true,
+         "requires": {
+            "querystringify": "^2.1.1",
+            "requires-port": "^1.0.0"
+         }
+      },
       "util": {
          "version": "0.12.5",
          "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -10586,6 +11455,15 @@
          "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
          "dev": true
       },
+      "w3c-xmlserializer": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+         "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+         "optional": true,
+         "requires": {
+            "xml-name-validator": "^5.0.0"
+         }
+      },
       "watchpack": {
          "version": "2.4.0",
          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -10604,6 +11482,12 @@
          "requires": {
             "minimalistic-assert": "^1.0.0"
          }
+      },
+      "webidl-conversions": {
+         "version": "7.0.0",
+         "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+         "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+         "optional": true
       },
       "webpack": {
          "version": "5.89.0",
@@ -10898,6 +11782,22 @@
             }
          }
       },
+      "whatwg-mimetype": {
+         "version": "4.0.0",
+         "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+         "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+         "optional": true
+      },
+      "whatwg-url": {
+         "version": "14.0.0",
+         "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+         "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+         "optional": true,
+         "requires": {
+            "tr46": "^5.0.0",
+            "webidl-conversions": "^7.0.0"
+         }
+      },
       "which": {
          "version": "2.0.2",
          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -10955,6 +11855,18 @@
          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
          "dev": true,
          "requires": {}
+      },
+      "xml-name-validator": {
+         "version": "5.0.0",
+         "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+         "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+         "optional": true
+      },
+      "xmlchars": {
+         "version": "2.2.0",
+         "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+         "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+         "optional": true
       },
       "xtend": {
          "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
       "@playwright/test": "1.40.1",
       "@types/jasmine": "5.1.4",
       "@types/json-diff": "1.0.3",
+      "@types/jsdom": "21.1.6",
       "@types/node": "20.10.6",
       "@types/pako": "1.0.7",
       "@types/webpack-env": "1.18.4",
@@ -76,6 +77,9 @@
    },
    "peerDependencies": {
       "excalibur": "~0.28.5"
+   },
+   "optionalDependencies": {
+      "jsdom": "^23.2.0"
    },
    "overrides": {
       "webpack-dev-server": {

--- a/src/parser/tiled-parser.ts
+++ b/src/parser/tiled-parser.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import * as jsdom from 'jsdom';
 
 const TiledIntProperty = z.object({
    name: z.string(),

--- a/src/resource/object-layer.ts
+++ b/src/resource/object-layer.ts
@@ -96,6 +96,7 @@ export class ObjectLayer implements Layer {
    }
 
    _actorFromObject(object: PluginObject, newActor: Actor, tileset?: Tileset): void {
+      const headless = this.resource.headless;
       const hasTint = !!this.tiledObjectLayer.tintcolor;
       const tint = this.tiledObjectLayer.tintcolor ? Color.fromHex(this.tiledObjectLayer.tintcolor) : Color.White;
 
@@ -109,26 +110,28 @@ export class ObjectLayer implements Layer {
          const scaleY = (object.tiledObject.width ?? this.resource.map.tilewidth) / this.resource.map.tilewidth;
          const scale = vec(scaleX, scaleY);
 
-         // need to clone because we are modify sprite properties, sprites are shared by default
-         const sprite = tileset.getSpriteForGid(object.gid).clone();
-         sprite.destSize.width = object.tiledObject.width ?? sprite.width;
-         sprite.destSize.height = object.tiledObject.height ?? sprite.height;
-         if (hasTint) {
-            sprite.tint = tint;
-         }
-
-         newActor.graphics.use(sprite);
-         newActor.graphics.offset = tileset.tileOffset;
-
-         const animation = tileset.getAnimationForGid(object.gid);
-         if (animation) {
-            const animationScaled = animation.clone();
-            animationScaled.scale = scale;
+         if (!headless) {
+            // need to clone because we are modify sprite properties, sprites are shared by default
+            const sprite = tileset.getSpriteForGid(object.gid).clone();
+            sprite.destSize.width = object.tiledObject.width ?? sprite.width;
+            sprite.destSize.height = object.tiledObject.height ?? sprite.height;
             if (hasTint) {
-               animationScaled.tint = tint;
+               sprite.tint = tint;
             }
-            newActor.graphics.use(animationScaled);
+
+            newActor.graphics.use(sprite);
             newActor.graphics.offset = tileset.tileOffset;
+
+            const animation = tileset.getAnimationForGid(object.gid);
+            if (animation) {
+               const animationScaled = animation.clone();
+               animationScaled.scale = scale;
+               if (hasTint) {
+                  animationScaled.tint = tint;
+               }
+               newActor.graphics.use(animationScaled);
+               newActor.graphics.offset = tileset.tileOffset;
+            }
          }
 
          // insertable tiles have an x, y, width, height, gid

--- a/src/resource/tile-layer.ts
+++ b/src/resource/tile-layer.ts
@@ -108,12 +108,16 @@ export class TileLayer implements Layer {
       }
 
       const tileset = this.resource.getTilesetForTileGid(gid);
-      let sprite = tileset.getSpriteForGid(gid);
-      if (hasTint) {
-         sprite = sprite.clone();
-         sprite.tint = tint;
+      const headless = this.resource.headless;
+
+      if (!headless) {
+         let sprite = tileset.getSpriteForGid(gid);
+         if (hasTint) {
+            sprite = sprite.clone();
+            sprite.tint = tint;
+         }
+         tile.addGraphic(sprite, { offset: tileset.tileOffset });
       }
-      tile.addGraphic(sprite, { offset: tileset.tileOffset });
 
 
       // the whole tilemap uses a giant composite collider relative to the Tilemap
@@ -123,7 +127,7 @@ export class TileLayer implements Layer {
          tile.addCollider(collider);
       }
 
-      let animation = tileset.getAnimationForGid(gid);
+      let animation = headless ? null : tileset.getAnimationForGid(gid);
       if (animation) {
          if (hasTint) {
             animation = animation.clone();

--- a/src/resource/tileset-resource.ts
+++ b/src/resource/tileset-resource.ts
@@ -59,27 +59,27 @@ export class TilesetResource implements Loadable<Tileset> {
 
          if (isTiledTilesetSingleImage(tileset)) {
             const imagePath = pathRelativeToBase(this.path, tileset.image, this.pathMap);
-            const image = this.imageLoader.getOrAdd(imagePath);
-            if (image) {
-               this.data = new Tileset({
-                  name: tileset.name,
-                  tiledTileset: tileset,
-                  firstGid: this.firstGid,
-                  image
-               });
-            }
+            const image = this.headless ? undefined : this.imageLoader.getOrAdd(imagePath);
+            this.data = new Tileset({
+               name: tileset.name,
+               tiledTileset: tileset,
+               firstGid: this.firstGid,
+               ...({ image }),
+            });
          }
 
          if (isTiledTilesetCollectionOfImages(tileset)) {
-            const tileToImage = new Map<TiledTile, ImageSource>();
-            const images: ImageSource[] = [];
-            if (tileset.tiles) {
-               for (let tile of tileset.tiles) {
-                  if (tile.image) {
-                     const imagePath = pathRelativeToBase(this.path, tile.image, this.pathMap);
-                     const image = this.imageLoader.getOrAdd(imagePath);
-                     tileToImage.set(tile, image);
-                     images.push(image);
+            const tileToImage = this.headless ? undefined : new Map<TiledTile, ImageSource>();
+            if (tileToImage) {
+               const images: ImageSource[] = [];
+               if (tileset.tiles) {
+                  for (let tile of tileset.tiles) {
+                     if (tile.image) {
+                        const imagePath = pathRelativeToBase(this.path, tile.image, this.pathMap);
+                        const image = this.imageLoader.getOrAdd(imagePath);
+                        tileToImage.set(tile, image);
+                        images.push(image);
+                     }
                   }
                }
             }
@@ -89,7 +89,7 @@ export class TilesetResource implements Loadable<Tileset> {
                name: tileset.name,
                tiledTileset: tileset,
                firstGid: this.firstGid,
-               tileToImage: tileToImage
+               ...({ tileToImage }),
             });
          }
 

--- a/src/resource/tileset.ts
+++ b/src/resource/tileset.ts
@@ -84,7 +84,7 @@ export class Tileset implements Properties {
       this.tiledTileset = tiledTileset;
       this.firstGid = firstGid;
 
-      if (isTiledTilesetSingleImage(tiledTileset) && image) {
+      if (isTiledTilesetSingleImage(tiledTileset)) {
          mapProps(this, tiledTileset.properties);
          const spacing = tiledTileset.spacing;
          const columns = Math.floor((tiledTileset.imagewidth + spacing) / (tiledTileset.tilewidth + spacing));
@@ -95,25 +95,27 @@ export class Tileset implements Properties {
          this.verticalFlipTransform = AffineMatrix.identity().translate(0, tiledTileset.tileheight).scale(1, -1);
          this.diagonalFlipTransform = AffineMatrix.identity().translate(0, 0).rotate(-Math.PI / 2).scale(-1, 1);
          this.objectalignment = tiledTileset.objectalignment ?? (this.orientation === 'orthogonal' ? 'bottomleft' : 'bottom');
-         this.spritesheet =  SpriteSheet.fromImageSource({
-            image,
-            grid: {
-               rows,
-               columns,
-               spriteWidth: tiledTileset.tilewidth,
-               spriteHeight: tiledTileset.tileheight
-            },
-            spacing: {
-               originOffset: {
-                  x: tiledTileset.margin ?? 0,
-                  y: tiledTileset.margin ?? 0
+         if (image) {
+            this.spritesheet =  SpriteSheet.fromImageSource({
+               image,
+               grid: {
+                  rows,
+                  columns,
+                  spriteWidth: tiledTileset.tilewidth,
+                  spriteHeight: tiledTileset.tileheight
                },
-               margin: {
-                  x: tiledTileset.spacing ?? 0,
-                  y: tiledTileset.spacing ?? 0
+               spacing: {
+                  originOffset: {
+                     x: tiledTileset.margin ?? 0,
+                     y: tiledTileset.margin ?? 0
+                  },
+                  margin: {
+                     x: tiledTileset.spacing ?? 0,
+                     y: tiledTileset.spacing ?? 0
+                  }
                }
-            }
-         });
+            });
+         }
          this.tileCount = tiledTileset.tilecount;
          this.tileWidth = tiledTileset.tilewidth;
          this.tileHeight = tiledTileset.tileheight;
@@ -125,12 +127,13 @@ export class Tileset implements Properties {
                this.tiles.push(new Tile({
                   id: tile.id,
                   tileset: this,
-                  tiledTile: tile
+                  tiledTile: tile,
+                  ...({ image })
                }))
             }
          }
       }
-      if (isTiledTilesetCollectionOfImages(tiledTileset) && tiledTileset.firstgid !== undefined && tileToImage) {
+      if (isTiledTilesetCollectionOfImages(tiledTileset) && tiledTileset.firstgid !== undefined) {
          this.horizontalFlipTransform = AffineMatrix.identity().translate(tiledTileset.tilewidth, 0).scale(-1, 1);
          this.verticalFlipTransform = AffineMatrix.identity().translate(0, tiledTileset.tileheight).scale(1, -1);
          this.diagonalFlipTransform = AffineMatrix.identity().translate(0, 0).rotate(-Math.PI / 2).scale(-1, 1);
@@ -145,19 +148,21 @@ export class Tileset implements Properties {
          let sprites: Sprite[] = []
          if (tiledTileset.tiles) {
             for (const tile of tiledTileset.tiles) {
-               const image = tileToImage.get(tile);
+               const image = tileToImage?.get(tile);
                if (image) {
-                  this.tiles.push(new Tile({
-                     id: tile.id,
-                     tileset: this,
-                     tiledTile: tile,
-                     image
-                  }))
                   sprites.push(image.toSprite())
                }
+               this.tiles.push(new Tile({
+                  id: tile.id,
+                  tileset: this,
+                  tiledTile: tile,
+                  ...({ image })
+               }))
             }
          }
-         this.spritesheet = new SpriteSheet({ sprites });
+         if (tileToImage) {
+            this.spritesheet = new SpriteSheet({ sprites });
+         }
       }
    }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,12 @@ module.exports = {
        commonjs2: "excalibur",
        amd: "excalibur",
        root: "ex"
+   },
+   "jsdom": {
+       commonjs: "JSDOM",
+       commonjs2: "JSDOM",
+       amd: "JSDOM",
+       root: "JSDOM"
    }
  },
  plugins: [

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -47,5 +47,13 @@ module.exports = {
       alias: {
          "@excalibur-tiled": path.resolve(__dirname, './src/')
       }
-   }
+   },
+   externals: {
+     "jsdom": {
+         commonjs: "JSDOM",
+         commonjs2: "JSDOM",
+         amd: "JSDOM",
+         root: "JSDOM"
+     }
+   },
 };


### PR DESCRIPTION
closes #483 

This PR adds [jsdom](https://www.npmjs.com/package/jsdom) as an optional dependency that can be detected and used in environments that don't have support for the browser-internal `DOMParser`.

Caveats: This also fixes the graphics component breaks I was running into when trying to run headless to actually test this. I can move that out into a separate Issue & PR if that makes sense to do. Essentially, I removed the loading of the actual image/sprite/animations when headless since it was breaking in Node when a browser graphic context wasn't there, even though headless would imply that not being necessary.

## Usage

When planning to use excalibur-tiled in Node.js or another non-browser environment, include jsdom when installing excalibur-tiled...

`npm i --save @excaliburjs/plugin-tiled@next jsdom`

or any time after if it's needed.

`npm i --save jsdom`