### PR TITLE
Fix empty infinite tile layer handling

### DIFF
--- a/src/resource/tile-layer.ts
+++ b/src/resource/tile-layer.ts
@@ -191,7 +191,8 @@ export class TileLayer implements Layer {
     }
 
     if (this.tilemap) {
-      const exTile = this.tilemap.getTile(x, y)!;
+      const exTile = this.tilemap.getTile(x, y);
+      if (!exTile) return null;
 
       const gid = this._getGidForTile(exTile);
 
@@ -316,6 +317,7 @@ export class TileLayer implements Layer {
     const tint = this.tiledTileLayer.tintcolor ? Color.fromHex(this.tiledTileLayer.tintcolor) : Color.Transparent;
     const isSolidLayer = !!this.properties.get(ExcaliburTiledProperties.Layer.Solid);
     const layer = this.tiledTileLayer;
+    const isEmptyInfiniteLayer = this.resource.map.infinite && isInfiniteLayer(layer) && layer.chunks.length === 0;
     const pos = vec(layer.offsetx ?? 0, layer.offsety ?? 0);
     if (this.tiledTileLayer.data && needsDecoding(this.tiledTileLayer)) {
       this.data = await Decoder.decode(this.tiledTileLayer.data, this.tiledTileLayer.compression);
@@ -367,7 +369,7 @@ export class TileLayer implements Layer {
     }
     const graphics = this.tilemap.get(GraphicsComponent);
     if (graphics) {
-      graphics.isVisible = this.tiledTileLayer.visible;
+      graphics.isVisible = this.tiledTileLayer.visible && !isEmptyInfiniteLayer;
       graphics.opacity = opacity;
     }
     if (layer.parallaxx || layer.parallaxy) {

--- a/test/unit/tiled-resource.spec.ts
+++ b/test/unit/tiled-resource.spec.ts
@@ -1,5 +1,5 @@
 import { FactoryProps, FetchLoader, TiledResource } from '@excalibur-tiled';
-import { Actor, BoundingBox, vec } from 'excalibur';
+import { Actor, BoundingBox, GraphicsComponent, vec } from 'excalibur';
 import type { ObjectLayer } from '../../src/resource/object-layer.js'
 
 describe('A Tiled map resource parser', () => {
@@ -417,6 +417,51 @@ describe('A Tiled map resource parser', () => {
       const tile = tiledMap.getTileByCoordinate('ground', 1, 1);
 
       expect(tile).not.toBeNull();
+   });
+
+   it('does not render or throw when an infinite tile layer has no chunks', async () => {
+      const tiledMap = new TiledResource('/test/unit/tiled/tiled-resource-spec/empty-infinite.tmj', {
+         headless: true,
+         fileLoader: async () => ({
+            type: 'map',
+            version: '1.10',
+            tiledversion: '1.10.2',
+            width: 0,
+            height: 0,
+            tilewidth: 16,
+            tileheight: 16,
+            infinite: true,
+            nextlayerid: 2,
+            nextobjectid: 1,
+            orientation: 'orthogonal',
+            renderorder: 'right-down',
+            layers: [
+               {
+                  id: 1,
+                  name: 'empty',
+                  type: 'tilelayer',
+                  visible: true,
+                  opacity: 1,
+                  x: 0,
+                  y: 0,
+                  width: 0,
+                  height: 0,
+                  startx: 0,
+                  starty: 0,
+                  chunks: []
+               }
+            ],
+            tilesets: []
+         })
+      });
+
+      await tiledMap.load();
+
+      const [layer] = tiledMap.getTileLayers('empty');
+      const graphics = layer.tilemap.get(GraphicsComponent);
+
+      expect(graphics.isVisible).toBe(false);
+      expect(tiledMap.getTileByCoordinate('empty', 0, 0)).toBeNull();
    });
 
 


### PR DESCRIPTION
## Summary
- Return `null` from tile coordinate lookup when Excalibur has no tile for the requested coordinate.
- Hide visible infinite tile layers that contain no chunks so an empty 0x0 TileMap is not rendered.
- Add a regression test for an empty infinite TMJ tile layer.

Fixes #828.

## Validation
- `npm test`
- `npm run build` (passes; existing webpack bundle-size warnings remain)
- `git diff --check`
- `gitleaks stdin --redact --no-banner --no-color` on the patch